### PR TITLE
tf.neg -> tf.negative

### DIFF
--- a/flip_gradient.py
+++ b/flip_gradient.py
@@ -10,7 +10,7 @@ class FlipGradientBuilder(object):
         grad_name = "FlipGradient%d" % self.num_calls
         @ops.RegisterGradient(grad_name)
         def _flip_gradients(op, grad):
-            return [tf.neg(grad) * l]
+            return [tf.negative(grad) * l]
         
         g = tf.get_default_graph()
         with g.gradient_override_map({"Identity": grad_name}):


### PR DESCRIPTION
As tf.mul, tf.sub and tf.neg are deprecated in favor of tf.multiply, tf.subtract and tf.negative in tensorflow 1.0.0.rc1 release. 
reference: https://github.com/tensorflow/tensorflow/releases/tag/v1.0.0-rc1